### PR TITLE
pass session token through to boto

### DIFF
--- a/flask_s3_viewer/__init__.py
+++ b/flask_s3_viewer/__init__.py
@@ -44,6 +44,7 @@ class FlaskS3Viewer(AWSS3Client, metaclass=Singleton):
         bucket_name
         secret_key
         access_key
+        session_token
         cache_dir
         ttl
         use_cache
@@ -88,6 +89,7 @@ class FlaskS3Viewer(AWSS3Client, metaclass=Singleton):
             config.setdefault('endpoint_url', None)
             config.setdefault('secret_key', None)
             config.setdefault('access_key', None)
+            config.setdefault('session_token', None)
             if config.get('use_cache'):
                 if not config.get('cache_dir'):
                     raise NotConfiguredCacheDir

--- a/flask_s3_viewer/aws/s3.py
+++ b/flask_s3_viewer/aws/s3.py
@@ -27,6 +27,7 @@ class AWSS3Client(AWSSession):
         bucket_name=None,
         secret_key=None,
         access_key=None,
+        session_token=None,
         cache_dir=None,
         ttl=None,
         use_cache=False
@@ -35,7 +36,8 @@ class AWSS3Client(AWSSession):
             profile_name=profile_name,
             region_name=region_name,
             secret_key=secret_key,
-            access_key=access_key
+            access_key=access_key,
+            session_token=session_token
         )
 
         if not self.runnable:

--- a/flask_s3_viewer/aws/session.py
+++ b/flask_s3_viewer/aws/session.py
@@ -11,7 +11,8 @@ class AWSSession:
         profile_name=None,
         region_name=None,
         secret_key=None,
-        access_key=None
+        access_key=None,
+        session_token=None,
     ):
         self.runnable = False
         self.profile_name = profile_name
@@ -26,6 +27,7 @@ class AWSSession:
                 self._session = boto3.Session(
                     aws_access_key_id=access_key,
                     aws_secret_access_key=secret_key,
+                    aws_session_token=session_token,
                     region_name=region_name
                 )
         except ClientError as e:


### PR DESCRIPTION
boto needs `aws_session_token` when using temporary credentials from AWS STS. For example, when assuming an IAM role.

See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials