### PR TITLE
Adding support to supply custom cert for endpoint urls with HTTPS

### DIFF
--- a/flask_s3_viewer/__init__.py
+++ b/flask_s3_viewer/__init__.py
@@ -48,6 +48,7 @@ class FlaskS3Viewer(AWSS3Client, metaclass=Singleton):
         cache_dir
         ttl
         use_cache
+        verify
         '''
     )
     template_namespace = NAMESPACE
@@ -96,6 +97,7 @@ class FlaskS3Viewer(AWSS3Client, metaclass=Singleton):
             config.setdefault('cache_dir', None)
             config.setdefault('ttl', 300)
             config.setdefault('use_cache', None)
+            config.setdefault('verify', None)
             super().__init__(**config)
 
         self.FLASK_S3_VIEWER_BUCKET_CONFIGS[namespace] = self.FLASK_S3_VIEWER_BUCKET(

--- a/flask_s3_viewer/aws/s3.py
+++ b/flask_s3_viewer/aws/s3.py
@@ -30,7 +30,8 @@ class AWSS3Client(AWSSession):
         session_token=None,
         cache_dir=None,
         ttl=None,
-        use_cache=False
+        use_cache=False,
+        verify=False
     ):
         super().__init__(
             profile_name=profile_name,
@@ -50,7 +51,8 @@ class AWSS3Client(AWSSession):
             's3',
             region_name=self.region_name,
             endpoint_url=endpoint_url,
-            config=Config(signature_version='s3v4')
+            config=Config(signature_version='s3v4'),
+            verify=verify
         )
         if use_cache:
             self._cache = AWSCache(


### PR DESCRIPTION
Boto3 needs cert to be supplied when communicating with s3 with endpoint instead of region.

[AWS_DOCS_LINK](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client)

The default value be set to False so that communication can happen with SSL warnings. 
